### PR TITLE
📅  fixes incorrect logic on `_resetValue` to determine datetime

### DIFF
--- a/PexelsClient.cs
+++ b/PexelsClient.cs
@@ -349,7 +349,7 @@ namespace PexelsDotNetSDK.Api
                 {
                     Limit = Convert.ToInt64(_limitValue),
                     Remaining = Convert.ToInt64(_remainingValue),
-                    Reset = _resetValue == null ? start.AddMilliseconds(Convert.ToInt64(_resetValue)).ToLocalTime() : start.ToLocalTime()
+                    Reset = _resetValue != null ? start.AddMilliseconds(Convert.ToInt64(_resetValue)).ToLocalTime() : start.ToLocalTime()
                 };
 
                 return output;


### PR DESCRIPTION
As pointed out here: https://github.com/pexels/PexelsDotNetSDK/issues/8
