### PR TITLE
📹  Add `fps` (where available) to video files output

### DIFF
--- a/Models/VideoFile.cs
+++ b/Models/VideoFile.cs
@@ -23,6 +23,9 @@ namespace PexelsDotNetSDK.Models
         [JsonProperty("height")]
         public int? height { get; set; }
 
+        [JsonProperty("fps")]
+        public double? fps { get; set; }
+
         [JsonProperty("link")]
         public string link { get; set; }
     }


### PR DESCRIPTION
Adds the new `fps` output to the `VideoFile` object (where available). 