### PR TITLE
AOT support

### DIFF
--- a/Models/Collection.cs
+++ b/Models/Collection.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/CollectionMedia.cs
+++ b/Models/CollectionMedia.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {
@@ -57,6 +62,5 @@ namespace PexelsDotNetSDK.Models
 
         [JsonProperty("liked")]
         public bool liked { get; set; }
-
     }
 }

--- a/Models/CollectionMediaPage.cs
+++ b/Models/CollectionMediaPage.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/CollectionPage.cs
+++ b/Models/CollectionPage.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/Page.cs
+++ b/Models/Page.cs
@@ -1,10 +1,15 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
+
 namespace PexelsDotNetSDK.Models
-{ 
+{
     public abstract class Page
     {
         [JsonProperty("page")]
@@ -21,7 +26,6 @@ namespace PexelsDotNetSDK.Models
 
         [JsonProperty("rate_limits")]
         public RateLimit rateLimit { get; set; }
-
     }
 
     public class RateLimit

--- a/Models/Photo.cs
+++ b/Models/Photo.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {
@@ -26,7 +31,7 @@ namespace PexelsDotNetSDK.Models
         public string photographerUrl { get; set; }
 
         [JsonProperty("photographer_id")]
-        public string photographerId { get; set; }
+        public long? photographerId { get; set; }
 
         [JsonProperty("src")]
         public Source source { get; set; }

--- a/Models/PhotoPage.cs
+++ b/Models/PhotoPage.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/Source.cs
+++ b/Models/Source.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,13 +1,17 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {
     public class User
     {
-
         [JsonProperty("id")]
         public int id { get; set; }
 

--- a/Models/Video.cs
+++ b/Models/Video.cs
@@ -1,13 +1,17 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {
     public class Video
     {
-
         [JsonProperty("id")]
         public int id { get; set; }
 

--- a/Models/VideoFile.cs
+++ b/Models/VideoFile.cs
@@ -1,13 +1,17 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {
     public class VideoFile
     {
-
         [JsonProperty("id")]
         public int id { get; set; }
 

--- a/Models/VideoPage.cs
+++ b/Models/VideoPage.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/Models/VideoPicture.cs
+++ b/Models/VideoPicture.cs
@@ -1,7 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+
+#if NET7_0_OR_GREATER
+using JsonProperty = System.Text.Json.Serialization.JsonPropertyNameAttribute;
+#else
+using Newtonsoft.Json;
+#endif
 
 namespace PexelsDotNetSDK.Models
 {

--- a/PexelsClient.cs
+++ b/PexelsClient.cs
@@ -1,11 +1,8 @@
-﻿using Newtonsoft.Json;
-using PexelsDotNetSDK.Models;
+﻿using PexelsDotNetSDK.Models;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
@@ -326,13 +323,14 @@ namespace PexelsDotNetSDK.Api
         {
             string responseBody = await response.Content.ReadAsStringAsync();
 
-            if (response.IsSuccessStatusCode)
-            {
+            if (!response.IsSuccessStatusCode)
+                throw new ErrorResponse(response.StatusCode, responseBody);
 
-                return JsonConvert.DeserializeObject<T>(responseBody);
-            }
-
-            throw new ErrorResponse(response.StatusCode, responseBody);
+#if NET7_0_OR_GREATER
+            return SerializerContext.Deserialize<T>(responseBody);
+#else
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseBody);
+#endif
         }
 
         private RateLimit ProcessRateLimits(HttpResponseMessage response)

--- a/PexelsDotNetSDK.csproj
+++ b/PexelsDotNetSDK.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net7.0</TargetFrameworks>
     <PackageId>PexelsDotNetSDK</PackageId>
-    <Description>A .NET Core wrapper for the Pexels.com API.
-</Description>
+    <Description>A .NET Core wrapper for the Pexels.com API.</Description>
     <Company>Pexels</Company>
     <Authors>Simon Gough</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -17,6 +16,17 @@
     <RepositoryType></RepositoryType>
     <PackageTags>pexels, images, videos</PackageTags>
   </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="SampleApp\**" />
+    <Content Remove="SampleApp\**" />
+    <EmbeddedResource Remove="SampleApp\**" />
+    <None Remove="SampleApp\**" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/PexelsDotNetSDK.sln
+++ b/PexelsDotNetSDK.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PexelsDotNetSDK", "PexelsDotNetSDK.csproj", "{5417359F-78E2-3A8C-5A13-4E52EF84FAFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleApp", "SampleApp\SampleApp.csproj", "{7BADA8CB-56E7-9A82-F46F-76EAEB094CA6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5417359F-78E2-3A8C-5A13-4E52EF84FAFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5417359F-78E2-3A8C-5A13-4E52EF84FAFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5417359F-78E2-3A8C-5A13-4E52EF84FAFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5417359F-78E2-3A8C-5A13-4E52EF84FAFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BADA8CB-56E7-9A82-F46F-76EAEB094CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BADA8CB-56E7-9A82-F46F-76EAEB094CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BADA8CB-56E7-9A82-F46F-76EAEB094CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BADA8CB-56E7-9A82-F46F-76EAEB094CA6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DF1A4229-1844-415D-A257-9BC690B4937E}
+	EndGlobalSection
+EndGlobal

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -1,0 +1,61 @@
+﻿using PexelsDotNetSDK.Api;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+try
+{
+    Console.WriteLine($"Runtime='{RuntimeInformation.FrameworkDescription}'");
+    Console.WriteLine($"Is AOT='{!RuntimeFeature.IsDynamicCodeSupported}'");
+
+    Console.WriteLine("Enter Pexels api key:");
+    string? key = Console.ReadLine();
+
+    PexelsClient client = new PexelsClient(key);
+
+    Console.WriteLine();
+    Console.WriteLine("Getting curated photos");
+    var curated = await client.CuratedPhotosAsync();
+    Console.WriteLine($"Curated: total='{curated.totalResults}'");
+
+    //foreach (var p in curated.photos)
+    //{
+    //    Console.WriteLine($"id='{p.id}', alt='{p.alt}', url='{p.url}'");
+    //}
+    
+    Console.WriteLine();
+    Console.WriteLine("Getting search results");
+    var searchResults = await client.SearchPhotosAsync("cat");
+    Console.WriteLine($"Results: total='{searchResults.totalResults}'");
+
+    //foreach (var p in searchResults.photos)
+    //{
+    //    Console.WriteLine($"id='{p.id}', alt='{p.alt}', url='{p.url}'");
+    //}
+
+    Console.WriteLine("Getting photo");
+    await client.GetPhotoAsync(2014422);
+
+    Console.WriteLine("Search video ");
+    var videoResults = await client.SearchVideosAsync("nature");
+
+    //foreach(var v in videoResults.videos)
+    //{
+    //    Console.WriteLine($"id='{v.id}', url='{v.url}'");
+    //}
+
+    Console.WriteLine("Getting popular video");
+    await client.PopularVideosAsync();
+
+    Console.WriteLine("Getting video");
+    await client.GetVideoAsync(2499611);
+
+    Console.WriteLine("Getting collections");
+    await client.CollectionsAsync();
+
+    Console.WriteLine("Getting featured collections");
+    await client.FeaturedCollectionsAsync();
+}
+catch (Exception ex)
+{
+    Console.WriteLine(ex.Message);
+}

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>warnings</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">
+    <IsAotCompatible>true</IsAotCompatible>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\PexelsDotNetSDK.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SerializerContext.cs
+++ b/SerializerContext.cs
@@ -1,0 +1,44 @@
+﻿#if NET7_0_OR_GREATER
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using PexelsDotNetSDK.Models;
+using System;
+
+namespace PexelsDotNetSDK
+{
+    [JsonSerializable(typeof(Collection))]
+    [JsonSerializable(typeof(CollectionMedia))]
+    [JsonSerializable(typeof(CollectionMediaPage))]
+    [JsonSerializable(typeof(CollectionPage))]
+    [JsonSerializable(typeof(Page))]
+    [JsonSerializable(typeof(Photo))]
+    [JsonSerializable(typeof(PhotoPage))]
+    [JsonSerializable(typeof(Source))]
+    [JsonSerializable(typeof(User))]
+    [JsonSerializable(typeof(Video))]
+    [JsonSerializable(typeof(VideoFile))]
+    [JsonSerializable(typeof(VideoPage))]
+    [JsonSerializable(typeof(VideoPicture))]
+    [JsonSerializable(typeof(RateLimit))]
+    sealed partial class SerializerContext : JsonSerializerContext
+    {
+        public static string Serialize<T>(T item)
+        {
+            return JsonSerializer.Serialize(item, typeof(T), Default);
+        }
+
+        public static T? Deserialize<T>(string json)
+        {
+            JsonTypeInfo<T>? typeInfo = Default.GetTypeInfo(typeof(T)) as JsonTypeInfo<T>;
+
+            if (typeInfo == null)
+                throw new InvalidOperationException($"Type {typeof(T).Name} not found");
+
+            return JsonSerializer.Deserialize<T>(json, typeInfo);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
This adds support for .NET AOT compilation when targeting net7.0 or above by using `System.Text.Json`, but continues to use `Newtonsoft.Json` when target below net7.0.

Also, a sample project used to test and demonstrate usage.